### PR TITLE
Add meilisearch mirror container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,3 +529,52 @@ jobs:
         export IMAGE_TAG="gcr.io/${{ secrets.GCP_PROJECT_ID }}/logstash:v$MAJOR_VERSION.$MINOR_VERSION.${{ steps.increment-patch-version.outputs.patch_version }}"
         docker build -t $IMAGE_TAG .
         docker push $IMAGE_TAG
+
+  push_snapshot_container_meilisearch:
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: meilisearch
+    env:
+      MAJOR_VERSION: 0
+      MINOR_VERSION: 0
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v1
+    - name: GCP Authenticate
+      uses: 'google-github-actions/auth@v1'
+      with:
+        credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+    - name: Setup GCloud
+      uses: 'google-github-actions/setup-gcloud@v1'
+      with:
+        version: '>= 363.0.0'
+
+    - name: Configure docker to use the gcloud cli
+      run: gcloud auth configure-docker --quiet
+
+    - name: Get latest version
+      id: get-latest-version
+      run: |
+        export LATEST_VERSION=$(gcloud container images list-tags gcr.io/${{ secrets.GCP_PROJECT_ID }}/meilisearch --format='get(tags)' --limit=1)
+        echo "::set-output name=latest_version::$LATEST_VERSION"
+
+    - name: Increment patch version
+      id: increment-patch-version
+      run: |
+        version=${{ steps.get-latest-version.outputs.latest_version }}
+        if [ -z "$version" ]; then
+          echo "Error: No version number provided."
+        fi
+        patch_version_exist=1
+        export PATCH_VERSION=$(($patch_version_exist + 1))
+        echo "::set-output name=patch_version::$PATCH_VERSION"
+
+    - name: Build and push container
+      run: |
+        export IMAGE_TAG="gcr.io/${{ secrets.GCP_PROJECT_ID }}/meilisearch:v$MAJOR_VERSION.$MINOR_VERSION.${{ steps.increment-patch-version.outputs.patch_version }}"
+        docker build -t $IMAGE_TAG .
+        docker push $IMAGE_TAG

--- a/meilisearch/Dockerfile
+++ b/meilisearch/Dockerfile
@@ -1,0 +1,1 @@
+FROM getmeili/meilisearch:v1.4

--- a/meilisearch/README.md
+++ b/meilisearch/README.md
@@ -1,0 +1,10 @@
+# meilisearch
+https://www.meilisearch.com/docs/learn/cookbooks/docker
+
+This is mirror image. <br>
+You get a network error when you getmeili/meilisearch:v1.4 directly from GCP.
+```
+  Warning  Failed   46m (x13 over 4h51m)     kubelet  Failed to pull image "getmeili/meilisearch:v1.4": rpc error: code = DeadlineExceeded desc = failed to pull and unpack image "docker.io/getmeili/meilisearch:v1.4": failed to resolve reference "docker.io/getmeili/meilisearch:v1.4": failed to do request: Head "https://registry-1.docker.io/v2/getmeili/meilisearch/manifests/v1.4": dial tcp xx.xx.xx.xx:443: i/o timeout
+
+```
+


### PR DESCRIPTION
## Overview
- Add new container which is for mirror.

If you get meilisearch directly in GCP, you will get the following error.
```
  Warning  Failed   46m (x13 over 4h51m)     kubelet  Failed to pull image "getmeili/meilisearch:v1.4": rpc error: code = DeadlineExceeded desc = failed to pull and unpack image "docker.io/getmeili/meilisearch:v1.4": failed to resolve reference "docker.io/getmeili/meilisearch:v1.4": failed to do request: Head "https://registry-1.docker.io/v2/getmeili/meilisearch/manifests/v1.4": dial tcp 44.205.64.79:443: i/o timeout
```