### PR TITLE
add filter for meili for more dynamical search

### DIFF
--- a/meilisearch/load_mysql.sh
+++ b/meilisearch/load_mysql.sh
@@ -12,9 +12,11 @@ SELECT
   p.product_id,
   p.product_name,
   s.seller_name,
-  p.price
+  p.price,
+  c.category_name
 FROM Product p
 JOIN Seller s ON p.seller_id = s.seller_id
+JOIN Category c ON p.category_id = c.category_id
 " > /tmp/products.csv
 
 # Count total lines
@@ -24,17 +26,18 @@ current_line=0
 # Convert CSV to JSON array
 {
   echo "["
-  while IFS=$'\t' read -r id name seller price
+  while IFS=$'\t' read -r id name seller price category
   do
     current_line=$((current_line + 1))
     id_clean=$(echo "$id" | tr -d '\000-\037' | sed 's/"/\\"/g')
     name_clean=$(echo "$name" | tr -d '\000-\037' | sed 's/"/\\"/g')
     seller_clean=$(echo "$seller" | tr -d '\000-\037' | sed 's/"/\\"/g')
+    category_clean=$(echo "$category" | tr -d '\000-\037' | sed 's/"/\\"/g')
 
     if [ "$current_line" -eq "$total_lines" ]; then
-      echo "  {\"product_id\":\"$id_clean\", \"product_name\":\"$name_clean\", \"seller_name\":\"$seller_clean\", \"price\":$price}"
+      echo "  {\"product_id\":\"$id_clean\", \"product_name\":\"$name_clean\", \"seller_name\":\"$seller_clean\", \"price\":$price, \"category_name\":\"$category_clean\"}"
     else
-      echo "  {\"product_id\":\"$id_clean\", \"product_name\":\"$name_clean\", \"seller_name\":\"$seller_clean\", \"price\":$price},"
+      echo "  {\"product_id\":\"$id_clean\", \"product_name\":\"$name_clean\", \"seller_name\":\"$seller_clean\", \"price\":$price, \"category_name\":\"$category_clean\"},"
     fi
   done < /tmp/products.csv
   echo "]"
@@ -50,5 +53,13 @@ curl -X PUT 'http://localhost:7700/indexes/products/settings/searchable-attribut
   -H 'Content-Type: application/json' \
   --data-binary '[
     "product_name",
-    "seller_name"
+    "seller_name",
+    "category_name"
+  ]'
+# Set filterableAttributes to restrict filterable fields
+  curl -X PUT 'http://meilisearch-service.default.svc.cluster.local:7700/indexes/products/settings/filterable-attributes' \
+  -H 'Content-Type: application/json' \
+  --data-binary '[
+    "seller_name",
+    "category_name"
   ]'

--- a/mysql/init.sql
+++ b/mysql/init.sql
@@ -1,30 +1,63 @@
-CREATE TABLE Seller (
-  seller_id VARCHAR(255) PRIMARY KEY,
-  seller_name VARCHAR(255)
+-- Create Seller table
+CREATE TABLE IF NOT EXISTS Seller (
+  seller_id VARCHAR(64) PRIMARY KEY,
+  seller_name VARCHAR(255),
+  last_update DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
-CREATE TABLE Product (
-  product_id VARCHAR(255) PRIMARY KEY,
+-- Create Category table
+CREATE TABLE IF NOT EXISTS Category (
+  category_id VARCHAR(3) PRIMARY KEY,
+  category_name VARCHAR(255),
+  last_update DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- Create Product table
+CREATE TABLE IF NOT EXISTS Product (
+  product_id VARCHAR(36) PRIMARY KEY,
   product_name VARCHAR(255),
-  seller_id VARCHAR(255),
+  seller_id VARCHAR(64),
   price INT,
-  category INT,
+  category_id VARCHAR(36),
   summary TEXT,
   regist_day DATETIME DEFAULT CURRENT_TIMESTAMP,
   last_update DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
 
-CREATE TABLE Stock (
-  product_id VARCHAR(255) PRIMARY KEY,
+-- Create Stock table
+CREATE TABLE IF NOT EXISTS Stock (
+  product_id VARCHAR(36) PRIMARY KEY,
   stocks INT
 );
 
-CREATE TABLE Wishlist (
-  user_id VARCHAR(255) PRIMARY KEY,
-  product_ids JSON NOT NULL, 
-  updated_at DATETIME
+-- Create Wishlist table
+CREATE TABLE IF NOT EXISTS Wishlist (
+  user_id VARCHAR(36) PRIMARY KEY,
+  product_ids JSON NOT NULL,
+  updated DATETIME
 );
 
+-- Insert Category data
+INSERT INTO Category (category_id, category_name) VALUES
+('01', 'Books'),
+('02', 'Music'),
+('03', 'Food&Drink'),
+('04', 'Game'),
+('05', 'Home'),
+('06', 'Fashion'),
+('07', 'Electronics'),
+('08', 'Hobby'),
+('09', 'Toy'),
+('10', 'Kids'),
+('11', 'Baby'),
+('12', 'Sports&Outdoor'),
+('13', 'Beauty'),
+('14', 'Car'),
+('15', 'Gifts'),
+('16', 'Health'),
+('99', 'Other');
+
+-- Insert Seller data
 INSERT INTO Seller (seller_id, seller_name) VALUES
 ('a38025d8-3598-4ccf-9d70-7e6dbf6edd09', 'Headphone company'),
 ('d3b4f7a37-0e05-4e04-8409-e5b0a55cf669', 'Greengrocer'),
@@ -32,13 +65,15 @@ INSERT INTO Seller (seller_id, seller_name) VALUES
 ('3cd8eabe-000d-4d5e-84eb-9cd6979cc0a6', 'Health company'),
 ('4377ba6b-e236-404b-a0e9-388126f7ee48', 'Sports company');
 
-INSERT INTO Product (product_id, product_name, seller_id, price, category, summary) VALUES
-('b150d47f-f4fb-40a2-a336-ac8e897af607', 'Bone conduction earphones', 'a38025d8-3598-4ccf-9d70-7e6dbf6edd09', 500, 1, 'Experience clear sound without blocking your ears.'),
-('580414f1-e962-4f6c-a461-d88d168e7cb1', 'Lemongrass', 'd3b4f7a37-0e05-4e04-8409-e5b0a55cf669', 6, 2, 'Fresh and aromatic lemongrass perfect for cooking or tea.'),
-('91e438c6-f073-4c57-95b3-0f98ccdedf34', 'Playing cards', '4dad4396-7f8b-46b8-a087-0ac3c63aeee9', 5, 3, 'Standard deck of playing cards for endless fun.'),
-('fe88e32f-678f-403a-bed2-331a4ff406c2', 'Protain bar', '3cd8eabe-000d-4d5e-84eb-9cd6979cc0a6', 20, 2, 'Delicious protein bars to power your workout.'),
-('d82f659a-a1ff-47f5-afb8-c93c02702fa4', 'Snowboard', '4377ba6b-e236-404b-a0e9-388126f7ee48', 100, 4, 'Designed for extreme winter sports with durability and sound clarity.');
+-- Insert Product data
+INSERT INTO Product (product_id, product_name, seller_id, price, category_id, summary) VALUES
+('b150d47f-f4fb-40a2-a336-ac8e897af607', 'Bone conduction earphones', 'a38025d8-3598-4ccf-9d70-7e6dbf6edd09', 500, '07', 'Experience clear sound without blocking your ears.'),
+('580414f1-e962-4f6c-a461-d88d168e7cb1', 'Lemongrass', 'd3b4f7a37-0e05-4e04-8409-e5b0a55cf669', 6, '03', 'Fresh and aromatic lemongrass perfect for cooking or tea.'),
+('91e438c6-f073-4c57-95b3-0f98ccdedf34', 'Playing cards', '4dad4396-7f8b-46b8-a087-0ac3c63aeee9', 5, '09', 'Standard deck of playing cards for endless fun.'),
+('fe88e32f-678f-403a-bed2-331a4ff406c2', 'Protain bar', '3cd8eabe-000d-4d5e-84eb-9cd6979cc0a6', 20, '16', 'Delicious protein bars to power your workout.'),
+('d82f659a-a1ff-47f5-afb8-c93c02702fa4', 'Snowboard', '4377ba6b-e236-404b-a0e9-388126f7ee48', 100, '12', 'Designed for extreme winter sports with durability and sound clarity.');
 
+-- Insert Stock data
 INSERT INTO Stock (product_id, stocks) VALUES
 ('b150d47f-f4fb-40a2-a336-ac8e897af607', 20),
 ('580414f1-e962-4f6c-a461-d88d168e7cb1', 50),

--- a/sync/sync_script.sh
+++ b/sync/sync_script.sh
@@ -14,14 +14,26 @@ fi
 LAST_SYNC=$(cat "$LAST_SYNC_FILE")
 
 mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASS -D $MYSQL_DB --batch --raw --silent -e "
-SELECT p.product_id, p.product_name, s.seller_name, p.price
+SELECT 
+  p.product_id, 
+  p.product_name, 
+  s.seller_name, 
+  p.price, 
+  c.category_id, 
+  c.category_name
 FROM Product p
 JOIN Seller s ON p.seller_id = s.seller_id
-WHERE p.last_update > '$LAST_SYNC'
+JOIN Category c ON p.category_id = c.category_id
+WHERE 
+  GREATEST(
+    IFNULL(p.last_update, '1970-01-01 00:00:00'),
+    IFNULL(s.last_update, '1970-01-01 00:00:00'),
+    IFNULL(c.last_update, '1970-01-01 00:00:00')
+  ) > '$LAST_SYNC'
 " > /tmp/updated_products.csv
 
 if [ -s /tmp/updated_products.csv ]; then
-  jq -R -s -f <(echo 'split("\n")[:-1] | map(split("\t")) | map({product_id:.[0], product_name:.[1], seller_name:.[2], price:(.[3]|tonumber)})') /tmp/updated_products.csv > /tmp/updated_products.json
+  jq -R -s -f <(echo 'split("\n")[:-1] | map(split("\t")) | map({product_id:.[0], product_name:.[1], seller_name:.[2], price:(.[3]|tonumber), category_id:.[4], category_name:.[5]})') /tmp/updated_products.csv > /tmp/updated_products.json
 
   curl -X POST 'http://meilisearch-service.default.svc.cluster.local:7700/indexes/products/documents' \
     -H 'Content-Type: application/json' \


### PR DESCRIPTION
Now we can search with category_name as well.
![CleanShot 2025-05-25 at 01 36 35@2x](https://github.com/user-attachments/assets/98644a01-0cb4-4288-a4bd-276fb39ed395)

Generally, meili returns the result from product_name, seller_name and category_name
![CleanShot 2025-05-25 at 01 35 56@2x](https://github.com/user-attachments/assets/8c2197ce-af34-4288-bca9-ed2d5a82ff08)
![CleanShot 2025-05-25 at 01 33 37@2x](https://github.com/user-attachments/assets/ae97ee88-91e7-45a5-a19c-7733eaa93427)

I added the module to filter with **ONLY (a) seller_name (b) category_name** for search result triggered from the product detail page.
Here is how you can search via API
 (a) seller_name
![CleanShot 2025-05-25 at 01 34 06@2x](https://github.com/user-attachments/assets/b9a9d80c-37ff-4108-9321-9c07afbf3767)

(b) category_name* 
![CleanShot 2025-05-25 at 01 33 50@2x](https://github.com/user-attachments/assets/13547906-7904-483f-9920-e43e6f01b5cc)

