### PR TITLE
Added logout button

### DIFF
--- a/ecfront2/src/components/Appbar.tsx
+++ b/ecfront2/src/components/Appbar.tsx
@@ -19,6 +19,7 @@ import {
   FavoriteBorder,
   Person,
 } from '@mui/icons-material';
+import { useAuth } from '../Auth';
 
 interface AppbarProps {
   onCartClick?: () => void;
@@ -40,6 +41,8 @@ const Appbar: React.FC<AppbarProps> = ({
   const [accountMenuAnchorEl, setAccountMenuAnchorEl] = useState<null | HTMLElement>(null);
   const accountMenuCloseTimerRef = useRef<number | null>(null);
   const isAccountMenuOpen = Boolean(accountMenuAnchorEl);
+  const auth = useAuth();
+
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -87,6 +90,18 @@ const Appbar: React.FC<AppbarProps> = ({
     } else {
       navigate('/user/account');
     }
+  };
+
+
+  const handleLogout = () => {
+    handleAccountMenuClose();
+
+    auth.logout?.();
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('id_token');
+    localStorage.removeItem('refresh_token');
+
+    navigate('/user/login');
   };
 
   const clearAccountMenuCloseTimer = () => {
@@ -254,6 +269,14 @@ const Appbar: React.FC<AppbarProps> = ({
               }}
             >
               Payment Options
+            </MenuItem>
+            <MenuItem
+              onClick={handleLogout}
+              sx={{
+                color: '#d32f2f',
+              }}
+            >
+              Logout
             </MenuItem>
           </Menu>
         </Box>


### PR DESCRIPTION
Added "logout" button to Account menu on Appbar.

<img width="317" height="293" alt="スクリーンショット 2026-05-05 10 00 50" src="https://github.com/user-attachments/assets/ee49b67d-b87f-4d7a-afe3-25ce2e0c4537" />

a user go back to login page when the user click this "logout" button. the user can login to mockten again by using the account he/she used before and can use new account like below screenshot. 

<img width="1034" height="367" alt="スクリーンショット 2026-05-05 10 02 49" src="https://github.com/user-attachments/assets/5518fd19-83bb-4b81-808b-3a9ba83e42e9" />


